### PR TITLE
DicomSTOWRSImportService regects import, because of mising quote signs

### DIFF
--- a/source/java/org/rsna/server/HttpRequest.java
+++ b/source/java/org/rsna/server/HttpRequest.java
@@ -521,7 +521,7 @@ public class HttpRequest {
 		String type = getContentType();
 		String typeLC = type.toLowerCase();
 		if (typeLC.contains("multipart/form-data")
-			|| (typeLC.contains("multipart/related") && typeLC.contains("type=application/dicom"))) {
+			|| (typeLC.contains("multipart/related") && typeLC.contains("application/dicom"))) {
 
 			// Check the content length
 			int length = getContentLength();


### PR DESCRIPTION
type=application/dicom vs type="application/dicom" e.g. used in python dicomweb-client
Without the quote sign, the typeLC.contains(...) is not matched. I don't know how it is handled in other DICOMWeb applications so I removed the "type=", so both conditions should match.